### PR TITLE
feat: 添加依赖 hibernate-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
             <version>1.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.hibernate/hibernate-core -->
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.4.2.Final</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
做作业的过程中，发现缺了这个依赖，课程代码无法启动。
版本: MacOS jdk 11